### PR TITLE
bower.json: bump AngularJS version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.7.2",
   "main": "./videogular.js",
   "dependencies": {
-    "angular": "~1.2.0",
-    "angular-sanitize": "~1.2.0"
+    "angular": "~1.3.x",
+    "angular-sanitize": "~1.3.x"
   }
 }


### PR DESCRIPTION
This PR bumps the `angular` (and `angular-sanitize`) versions from `~1.2.0` to `1.3.x`. The versions could also be changed to `>=1.2.0`, but since [the main repo](https://github.com/2fdevs/videogular/blob/630ffbf945bcd75554ab4672e23b979140fcb0f4/bower.json) specifies `~1.3.4` I guess `1.3.x` is sufficient.
