### PR TITLE
bower.json: allow AngularJS versions greater than 1.3.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.2.6",
   "main": "./videogular.js",
   "dependencies": {
-    "angular": "~1.3.x",
-    "angular-sanitize": "~1.3.x"
+    "angular": "^1.3.x",
+    "angular-sanitize": "^1.3.x"
   }
 }


### PR DESCRIPTION
Allows AngularJS 1.4 and upcoming versions in the 1.x range.
