### PR TITLE
Removed dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-require('angular');
-require('angular-sanitize');
 require('./videogular');
 
 module.exports = 'com.2fdevs.videogular';


### PR DESCRIPTION
Removed `angular` and `angular-sanitize` dependencies, as they break building project with Browserify if `angular` is bundled as a non-npm module (`Error: Cannot find module 'angular'`). Requiring these doesn't have to occur in a plugin, they are usually required somewhere in the app.
