### PR TITLE
Catching error state when event.target.buffered is null

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "videogular",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "./videogular.js",
   "dependencies": {
     "angular": "^1.3.x",

--- a/videogular.js
+++ b/videogular.js
@@ -204,7 +204,7 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onProgress = function (event) {
-            if (event.target.buffered.length) {
+            if (event.target.buffered && event.target.buffered.length) {
                 this.buffered = event.target.buffered;
                 this.bufferEnd = 1000 * event.target.buffered.end(event.target.buffered.length - 1);
             }
@@ -215,7 +215,7 @@ angular.module("com.2fdevs.videogular")
         this.onUpdateTime = function (event) {
             this.currentTime = 1000 * event.target.currentTime;
 
-            if (event.target.buffered.length) {
+            if (event.target.buffered && event.target.buffered.length) {
                 this.buffered = event.target.buffered;
                 this.bufferEnd = 1000 * event.target.buffered.end(event.target.buffered.length - 1);
             }


### PR DESCRIPTION
Adding a null-check to event.target.buffered. This is often null, especially when used in conjunction with the videogular-flash plugin.  In these cases, without the null check, the vgUpdateTime event is never called.
